### PR TITLE
Single task celery callbacks

### DIFF
--- a/demo/models.py
+++ b/demo/models.py
@@ -1,8 +1,7 @@
 from django.db import models
+from django_logic.process import ProcessManager
 
 from demo.process import InvoiceProcess
-
-from django_logic.process import ProcessManager
 
 
 class Invoice(ProcessManager.bind_state_fields(status=InvoiceProcess), models.Model):

--- a/demo/process.py
+++ b/demo/process.py
@@ -1,9 +1,12 @@
 from django_logic import Process, Transition
+
 from django_logic_celery import SideEffectTasks, CallbacksTasks
 
 
-class InProgressTransition(Transition):
-    side_effects = SideEffectTasks()
+class CeleryTransition(Transition):
+    side_effects_class = SideEffectTasks
+    callbacks_class = CallbacksTasks
+    failure_callbacks_class = CallbacksTasks
 
 
 class ProgressTransition(Transition):
@@ -29,7 +32,7 @@ class InvoiceProcess(Process):
             sources=['draft'],
             target='approved'
         ),
-        InProgressTransition(
+        CeleryTransition(
             action_name='send_to_customer',
             sources=['approved'],
             side_effects=['demo.tasks.send_to_a_customer'],
@@ -40,7 +43,7 @@ class InvoiceProcess(Process):
             sources=['draft', 'paid'],
             target='voided'
         ),
-        ProgressTransition(
+        CeleryTransition(
             action_name='demo',
             sources=['draft'],
             target='sent',

--- a/django_logic_celery/__init__.py
+++ b/django_logic_celery/__init__.py
@@ -1,2 +1,2 @@
-from .commands import SideEffectTasks, CallbacksTasks
-from .transitions import CeleryCallbackTransition, CeleryTransition, InProgressTransition
+from .commands import SideEffectTasks, CallbacksTasks, SideEffectSingleTask, CallbacksSingleTask
+from .transitions import CeleryCallbackTransition, CeleryTransition, InProgressTransition, CelerySingleTaskTransition

--- a/django_logic_celery/commands.py
+++ b/django_logic_celery/commands.py
@@ -41,16 +41,55 @@ def fail_transition(task_id, *args, **kwargs):
         print('Exception')
 
 
-class SideEffectTasks(SideEffects):
+@shared_task(acks_late=True)
+def run_side_effects_as_task(**kwargs):
+    app = apps.get_app_config(kwargs['app_label'])
+    model = app.get_model(kwargs['model_name'])
+    instance = model.objects.get(id=kwargs['instance_id'])
+    field_name = kwargs.pop('field_name')
+    transition = kwargs['transition']
+    try:
+        for side_effect in transition.side_effects.commands:
+            side_effect(instance)
+    except Exception:
+        transition.fail_transition(instance, field_name, **kwargs)
+
+    transition.complete_transition(instance, field_name, **kwargs)
+
+
+@shared_task(acks_late=True)
+def run_callbacks_as_task(**kwargs):
+    app = apps.get_app_config(kwargs['app_label'])
+    model = app.get_model(kwargs['model_name'])
+    instance = model.objects.get(id=kwargs['instance_id'])
+    transition = kwargs['transition']
+
+    for callback in transition.callbacks.commands:
+        callback(instance)
+
+
+class CeleryTaskMixin:
     def execute(self, instance: any, field_name: str, **kwargs):
         if not self.commands:
-            return super(SideEffectTasks, self).execute(instance, field_name)
+            return super().execute(instance, field_name)
 
-        task_kwargs = dict(app_label=instance._meta.app_label,
-                           model_name=instance._meta.model_name,
-                           instance_id=instance.pk,
-                           field_name=field_name)
+        task_kwargs = self.get_task_kwargs(instance, field_name)
+        self.queue_task(task_kwargs)
 
+    def get_task_kwargs(self, instance: any, field_name: str, **kwargs):
+        return dict(
+            app_label=instance._meta.app_label,
+            model_name=instance._meta.model_name,
+            instance_id=instance.pk,
+            field_name=field_name
+        )
+
+    def queue_task(self, task_kwargs):
+        return NotImplementedError
+
+
+class SideEffectTasks(CeleryTaskMixin, SideEffects):
+    def queue_task(self, task_kwargs):
         header = [signature(task_name, kwargs=task_kwargs) for task_name in self.commands]
         header = chain(*header)
         task_kwargs.update(dict(transition=self._transition))
@@ -59,15 +98,29 @@ class SideEffectTasks(SideEffects):
         transaction.on_commit(tasks.delay)
 
 
-class CallbacksTasks(Callbacks):
-    def execute(self, instance, field_name: str, **kwargs):
-        if not self.commands:
-            return super(CallbacksTasks, self).execute(instance, field_name)
-
-        task_kwargs = dict(app_label=instance._meta.app_label,
-                           model_name=instance._meta.model_name,
-                           instance_id=instance.pk,
-                           field_name=field_name)
-
+class CallbacksTasks(CeleryTaskMixin, Callbacks):
+    def queue_task(self, task_kwargs):
         tasks = [signature(task_name, kwargs=task_kwargs) for task_name in self.commands]
         transaction.on_commit(group(tasks))
+
+
+class SideEffectSingleTask(CeleryTaskMixin, SideEffects):
+    def get_task_kwargs(self, instance: any, field_name: str, **kwargs):
+        task_kwargs = super().get_task_kwargs(instance, field_name, **kwargs)
+        task_kwargs['transition'] = self._transition
+        return task_kwargs
+
+    def queue_task(self, task_kwargs):
+        sig = run_side_effects_as_task.signature(kwargs=task_kwargs)
+        transaction.on_commit(sig.delay)
+
+
+class CallbacksSingleTask(CeleryTaskMixin, Callbacks):
+    def get_task_kwargs(self, instance: any, field_name: str, **kwargs):
+        task_kwargs = super().get_task_kwargs(instance, field_name, **kwargs)
+        task_kwargs['transition'] = self._transition
+        return task_kwargs
+
+    def queue_task(self, task_kwargs):
+        sig = run_callbacks_as_task.signature(kwargs=task_kwargs)
+        transaction.on_commit(sig.delay)

--- a/django_logic_celery/transitions.py
+++ b/django_logic_celery/transitions.py
@@ -1,6 +1,6 @@
 from django_logic import Transition
 
-from django_logic_celery import SideEffectTasks, CallbacksTasks
+from django_logic_celery import SideEffectTasks, CallbacksTasks, SideEffectSingleTask
 
 
 class InProgressTransition(Transition):
@@ -14,3 +14,7 @@ class CeleryCallbackTransition(Transition):
 class CeleryTransition(Transition):
     side_effects_class = SideEffectTasks
     callbacks_class = CallbacksTasks
+
+
+class CelerySingleTaskTransition(Transition):
+    side_effects_class = SideEffectSingleTask

--- a/tests/test_side_effects.py
+++ b/tests/test_side_effects.py
@@ -1,16 +1,12 @@
 from django.test import TestCase
-from django_logic import Process, Transition
+from django_logic import Process
 
 from demo.models import Invoice
-from django_logic_celery import SideEffectTasks
+from django_logic_celery import InProgressTransition
 
 
 class User:
     is_allowed = True
-
-
-class InProgressTransition(Transition):
-    side_effects = SideEffectTasks()
 
 
 class ApplyTransitionTestCase(TestCase):


### PR DESCRIPTION
Implements functionality that allows running side effects and callbacks not as separate Celery tasks, but as functions inside a single internal Celery task.